### PR TITLE
replace intuita with codemod.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@
 
 Codemod Registry is an open-source, single-stop repository for codemods and code automation recipes. Codemod Registry brings an ever-growing variety of helpful codemods all in one place.
 
-Codemods available in Codemod Registry are automatically integrated into [Intuita's platform](https://docs.intuita.io/docs/intro) and all developers who have Intuita's CLI or IDE extension can then discover, share, and run those codemods with a single click.
+Codemods available in Codemod Registry are automatically integrated into [Codemod.com's platform](https://docs.codemod.com/docs/intro) and all developers who have Codemod.com's CLI or IDE extension can then discover, share, and run those codemods with a single click.
 
-Currently, Intuita's platform supports `jscodeshift`, `ts-morph`, and Uber's Piranha codemod engines. If you would like to see a specific codemod engine supported, please [leave us a feature request](https://feedback.intuita.io/feature-requests-and-bugs).
+Currently, Codemod.com's platform supports `jscodeshift`, `ts-morph`, and Uber's Piranha codemod engines. If you would like to see a specific codemod engine supported, please [leave us a feature request](https://feedback.codemod.com/feature-requests-and-bugs).
 
-If there is a codemod you would like to see available in Codemod Registry, please consider opening a PR to add the codemod. Learn [more about contributing here](#contributing).
+If there is a codemod you would like to see available in Codemod Registry, please consider opening a PR to add the codemod. Learn [more about contributing here](/CONTRIBUTING.md).
 
 ## Why use Codemod Registry
 
 Adding or using codemods in Codemod Registry allows for:
 
-🔗 Automatic integration with the Intuita [CLI](https://docs.intuita.io/docs/cli/quickstart) and [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension).
+🔗 Automatic integration with the Codemod.com [CLI](https://docs.codemod.com/docs/cli/quickstart) and [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Intuita.intuita-vscode-extension).
 
-:octocat: Ensuring codemods are reviewed and improved by [a community of codemod experts](https://join.slack.com/t/intuita-inc/shared_invite/zt-1tvxm6ct0-mLZld_78yguDYOSM7DM7Cw).
+:octocat: Ensuring codemods are reviewed and improved by [a community of codemod experts](https://codemod.com/community).
 
 🌍 Making codemods more accessible to many developers around the world.
 
@@ -55,22 +55,22 @@ Adding or using codemods in Codemod Registry allows for:
 
 ## Running codemods in the registry
 
-All codemods in the registry are automatically distributed to Intuita's CLI and IDE extension.
+All codemods in the registry are automatically distributed to Codemod.com's CLI and IDE extension.
 
 To run any codemod in the registry, you can:
 
--   [Run codemod using Intuita VS Code extension](https://docs.intuita.io/docs/vs-code-extension/advanced-usage#dry-running-codemods).
--   [Run codemod using Intuita CLI](https://docs.intuita.io/docs/cli/quickstart).
+-   [Run codemod using Codemod.com VS Code extension](https://docs.codemod.com/docs/vs-code-extension/advanced-usage#dry-running-codemods).
+-   [Run codemod using Codemod.com CLI](https://docs.codemod.com/docs/cli/quickstart).
 
 ## Contributing
 
 Codemod Registry is an open-source, community-first, and community-powered project made for developers, by developers.
 
-If you would like to contribute to the Codemod Registry, please [follow our contribution guide](https://docs.intuita.io/docs/codemod-registry/importing-codemods). Please note that once you create a pull request, you will be asked to sign our Contributor License Agreement.
+If you would like to contribute to the Codemod Registry, please [follow our contribution guide](https://docs.codemod.com/docs/codemod-registry/importing-codemods). Please note that once you create a pull request, you will be asked to sign our Contributor License Agreement.
 
-If you are a codemod builder and/or interested in codemods, please [join our community](https://intuita.io/community)!
+If you are a codemod builder and/or interested in codemods, please [join our community](https://codemod.com/community)!
 
-If you are not a codemod developer, but you would like to have the community contribute on developing a codemod you’re interested in, then feel free to [request a codemod here](https://feedback.intuita.io/codemod-requests).
+If you are not a codemod developer, but you would like to have the community contribute on developing a codemod you’re interested in, then feel free to [request a codemod here](https://feedback.codemod.com/codemod-requests).
 
 ## Contributors ✨
 
@@ -85,7 +85,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://maxleiter.com/"><img src="https://avatars.githubusercontent.com/u/8675906?v=4?s=100" width="100px;" alt="Max Leiter"/><br /><sub><b>Max Leiter</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=MaxLeiter" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://medium.com/@greg-pabian/"><img src="https://avatars.githubusercontent.com/u/35925521?v=4?s=100" width="100px;" alt="Greg Pabian"/><br /><sub><b>Greg Pabian</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=grzpab" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/issues?q=author%3Agrzpab" title="Bug reports">🐛</a> <a href="https://github.com/codemod-com/codemod-registry/commits?author=grzpab" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/DmytroHryshyn"><img src="https://avatars.githubusercontent.com/u/125881252?v=4?s=100" width="100px;" alt="DmytroHryshyn"/><br /><sub><b>DmytroHryshyn</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=DmytroHryshyn" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/issues?q=author%3ADmytroHryshyn" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://intuita.io/"><img src="https://avatars.githubusercontent.com/u/78109534?v=4?s=100" width="100px;" alt="Alex Bit"/><br /><sub><b>Alex Bit</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=alex-from-intuita" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/commits?author=alex-from-intuita" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/alexbit-codemod"><img src="https://avatars.githubusercontent.com/u/78109534?v=4?s=100" width="100px;" alt="Alex Bit"/><br /><sub><b>Alex Bit</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=alexbit-codemod" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/commits?author=alexbit-codemod" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hbjORbj"><img src="https://avatars.githubusercontent.com/u/32841130?v=4?s=100" width="100px;" alt="Benny Joo"/><br /><sub><b>Benny Joo</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=hbjORbj" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/issues?q=author%3AhbjORbj" title="Bug reports">🐛</a> <a href="https://github.com/codemod-com/codemod-registry/commits?author=hbjORbj" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mohab-sameh"><img src="https://avatars.githubusercontent.com/u/37941642?v=4?s=100" width="100px;" alt="Mohab Sameh"/><br /><sub><b>Mohab Sameh</b></sub></a><br /><a href="https://github.com/codemod-com/codemod-registry/commits?author=mohab-sameh" title="Code">💻</a> <a href="https://github.com/codemod-com/codemod-registry/commits?author=mohab-sameh" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://zergus.github.io/"><img src="https://avatars.githubusercontent.com/u/5468045?v=4?s=100" width="100px;" alt="Serhii Melnyk"/><br /><sub><b>Serhii Melnyk</b></sub></a><br /><a href="#ideas-Zergus" title="Ideas, Planning, & Feedback">🤔</a></td>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**:

-   [x] The commit message follows [our code of conduct](https://github.com/codemod-com/codemod-registry/blob/main/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md)

**Please include the following information in your pull request**:

*   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Replacing occurrences and links from Intuita to Codemod.com.

*   **What is the current behavior?** (You can also link to an open issue here)
README.md doc used to refer to the company as Intuita.
Outgoing links used to point to Intuita.io domain and subdomains.

*   **What is the new behavior (if this is a feature change)?**
README.md doc refers to the company as Codemod.com.
Outgoing links point to Codemod.com domain and subdomains.

*   **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
N/A.

*   **Any other information (if needed)**:
N/A.
